### PR TITLE
removing additional sessionList split

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -343,7 +343,6 @@ if __name__ == "__main__":
         opts.sessionList =np.unique( [ sub('_','',sub('ses-', '',os.path.basename(f))) for f in glob(opts.sourceDir+os.sep+"**/*ses-*") ])
         print("Warning : No session variables. Will run all sessions found in source directory "+ opts.sourceDir)
         print("Sessions:", ' '.join( opts.sessionList))
-    else : opts.sessionList=opts.sessionList.split(',')
 
     #########################
     #Automatically set tasks#


### PR DESCRIPTION
The line getting removed in this PR was throwing an error since the sessionList had already been split into a list using the `get_opt_list` function.