### PR TITLE
Fix _gen_filename() for reshape method 

### DIFF
--- a/Extra/reshape.py
+++ b/Extra/reshape.py
@@ -21,7 +21,7 @@ class ReshapeInput(CommandLineInputSpec):
 
 class ReshapeCommand(CommandLine):
     _cmd = "mincreshape"
-    _suffix = "_mincreshape"
+    _suffix = "_reshape"
     input_spec = ReshapeInput
     output_spec = ReshapeOutput
 

--- a/Extra/reshape.py
+++ b/Extra/reshape.py
@@ -38,9 +38,7 @@ class ReshapeCommand(CommandLine):
         outputs["out_file"] = self.inputs.out_file
         return outputs
 
-    def _gen_filename(self, name):
-        if name == "out_file":
-            return self._list_outputs()["out_file"]
-        return None
-
+    def _gen_filename(self, in_file, suffix):
+        split_in_file = os.path.splitext(os.path.basename(self.inputs.in_file))
+        return os.getcwd() + os.sep + split_in_file[0] + suffix + split_in_file[1]
 


### PR DESCRIPTION
The output file wasn't being returned before, and the `suffix` arg is added to the function. 